### PR TITLE
Document things relating to authorization

### DIFF
--- a/docs/cloudlink/commands/authpswd.md
+++ b/docs/cloudlink/commands/authpswd.md
@@ -1,0 +1,31 @@
+---
+slug: /cloudlink/commands/authpswd
+sidebar_label: authpswd
+---
+
+# `authpswd`
+
+This command is used to log into Meower.
+
+## Request
+
+<!-- prettier-ignore-start -->
+| Field | Type | Description |
+| - | - | - |
+| username | string | The username of the account to log into. This has to be between 1 and 20 characters. |
+| pswd | string | The password or a token of the account to log into. This has to be between 1 and 255 characters. |
+<!-- prettier-ignore-end -->
+
+## Response
+
+<!-- prettier-ignore-start -->
+| Status code | Description |
+| - | - |
+| I:011 \| Invalid Password | If the password of the account was invalid. |
+| I:100 \| OK | If the log in attempt was succesful. This also sends an `auth` packet. |
+| E:018 \| Account Banned | If the account was banned. |
+| E:025 \| Deleted | If the account was deleted and can't be logged into. |
+| E:101 \| Syntax | If either `username` or `pswd` aren't included in the packet, or the length limits for them aren't met. |
+| E:102 \| Datatype | If the provided `val` is not an object, or if the `username` or `pswd` aren't strings. |
+| E:103 \| ID not found | If the given user does not exist. |
+<!-- prettier-ignore-end -->

--- a/docs/cloudlink/intro.md
+++ b/docs/cloudlink/intro.md
@@ -1,0 +1,14 @@
+---
+slug: /cloudlink
+sidebar_label: Intro
+---
+
+# Intro
+
+<!--
+  TODO
+  Points to mention:
+    - What Cloudlink is
+    - How to connect to the Cloudlink server
+    - The general request/response shape
+-->

--- a/docs/cloudlink/packets/auth.md
+++ b/docs/cloudlink/packets/auth.md
@@ -1,0 +1,29 @@
+---
+slug: /cloudlink/packets/auth
+sidebar_label: auth
+---
+
+# `auth`
+
+This packet is sent when the user has successfully logged in. It has two keys: a `mode` of `"auth"` and a `payload`.
+
+## Payload
+
+<!-- prettier-ignore-start -->
+| Field | Type | Description |
+| - | - | - |
+| username | string | The username of the account. |
+| token | string | The token of this connection. A new one will be generated each time, but they don't expire unless manually revoked. |
+| account | [User](../../objects/user) object | The account information of the logged in account. |
+| relationships | array of relationships | See below for more details. |
+<!-- prettier-ignore-end-->
+
+## Relationship
+
+<!-- prettier-ignore-start -->
+
+| Field      | Type   | Description                                                                   |
+| ---------- | ------ | ----------------------------------------------------------------------------- |
+| username   | string | The user with whom the account has a relationship.                            |
+| state      | number | Always 2, meaning that the user is blocked.                                   |
+| updated_at | number | The Unix seconds representation of the date the relationship was last updated |

--- a/docs/rest-api/intro/authentication.md
+++ b/docs/rest-api/intro/authentication.md
@@ -4,3 +4,16 @@ sidebar_label: Authentication
 ---
 
 # Authentication
+
+Most endpoints require authorization to use them. Authentication can be provided using a header named "`Token`", which is set to a Meower token. A token can be obtained by [logging into the Cloudlink server](../../cloudlink/commands/authpswd). Logging in with the API currently isn't supported.
+
+If you do not provide a token to endpoints that require authorization, the response will have a status of 403.
+
+**Response body of an unauthenticated request**
+
+```json
+{
+  "error": true,
+  "type": "Unauthorized"
+}
+```

--- a/docs/rest-api/intro/authentication.md
+++ b/docs/rest-api/intro/authentication.md
@@ -7,7 +7,7 @@ sidebar_label: Authentication
 
 Most endpoints require authorization to use them. Authentication can be provided using a header named "`Token`", which is set to a Meower token. A token can be obtained by [logging into the Cloudlink server](../../cloudlink/commands/authpswd). Logging in with the API currently isn't supported.
 
-If you do not provide a token to endpoints that require authorization, the response will have a status of 403.
+If you do not provide a token to endpoints that require authorization, the response will have a status of 401.
 
 **Response body of an unauthenticated request**
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -74,6 +74,12 @@ const config = {
             label: 'REST API',
           },
           {
+            type: 'docSidebar',
+            sidebarId: 'cloudlink',
+            position: 'left',
+            label: 'Cloudlink',
+          },
+          {
             href: 'https://app.meower.org',
             label: 'Meower',
             position: 'right',

--- a/sidebars.js
+++ b/sidebars.js
@@ -13,20 +13,21 @@
 
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
-  sidebar: [
-    'root/intro'
-  ],
+  sidebar: ["root/intro"],
   objects: [
-    'objects/user',
-    'objects/user-settings',
-    'objects/user-ban',
-    'objects/chat',
-    'objects/post',
-    'objects/extended-timestamp'
+    "objects/user",
+    "objects/user-settings",
+    "objects/user-ban",
+    "objects/chat",
+    "objects/post",
+    "objects/extended-timestamp",
   ],
-  restApi: [
-    'rest-api/intro/authentication'
-  ]
+  restApi: ["rest-api/intro/authentication"],
+  cloudlink: [
+    "cloudlink/intro",
+    "cloudlink/commands/authpswd",
+    "cloudlink/packets/auth",
+  ],
 };
 
 module.exports = sidebars;


### PR DESCRIPTION
Documents:
- The `Token` header
- The `authpswd` Cloudlink command
- The `auth` resposnse packet