### PR TITLE
Enforce `deno fmt` formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint and format
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.44.4
+      - run: deno fmt --check .
+    continue-on-error: true
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.44.4
+      - run: deno lint .
+    continue-on-error: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["denoland.vscode-deno"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+	"[javascript]": {
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+	"[markdown]": {
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+	"[json]": {
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+	"editor.insertSpaces": false
+}

--- a/docs/api/cloudlink/commands/authpswd.md
+++ b/docs/api/cloudlink/commands/authpswd.md
@@ -1,7 +1,3 @@
--
-
-## title: authpswd command
-
 # `authpswd`
 
 This command is used to log into Meower.

--- a/docs/api/cloudlink/commands/authpswd.md
+++ b/docs/api/cloudlink/commands/authpswd.md
@@ -1,6 +1,6 @@
----
-title: authpswd command
----
+-
+
+## title: authpswd command
 
 # `authpswd`
 
@@ -8,19 +8,23 @@ This command is used to log into Meower.
 
 ## Request
 
-| Field    | Type   | Description                                                                                      |
-| -------- | ------ | ------------------------------------------------------------------------------------------------ |
-| username | string | The username of the account to log into. This has to be between 1 and 20 characters.             |
-| pswd     | string | The password or a token of the account to log into. This has to be between 1 and 255 characters. |
+<!-- deno-fmt-ignore-start -->
+| Field | Type | Description |
+| - | - | - |
+| username | string | The username of the account to log into. This has to be between 1 and 20 characters. |
+| pswd | string | The password or a token of the account to log into. This has to be between 1 and 255 characters. |
+<!-- deno-fmt-ignore-end -->
 
 ## Response
 
-| Status code               | Description                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| I:011 \| Invalid Password | If the password of the account was invalid.                                                             |
-| I:100 \| OK               | If the log in attempt was succesful. This also sends an `auth` packet.                                  |
-| E:018 \| Account Banned   | If the account was banned.                                                                              |
-| E:025 \| Deleted          | If the account was deleted and can't be logged into.                                                    |
-| E:101 \| Syntax           | If either `username` or `pswd` aren't included in the packet, or the length limits for them aren't met. |
-| E:102 \| Datatype         | If the provided `val` is not an object, or if the `username` or `pswd` aren't strings.                  |
-| E:103 \| ID not found     | If the given user does not exist.                                                                       |
+<!-- deno-fmt-ignore-start -->
+| Status code | Description |
+| - | - |
+| I:011 \| Invalid Password | If the password of the account was invalid. |
+| I:100 \| OK | If the log in attempt was succesful. This also sends an `auth` packet. |
+| E:018 \| Account Banned | If the account was banned. |
+| E:025 \| Deleted | If the account was deleted and can't be logged into. |
+| E:101 \| Syntax | If either `username` or `pswd` aren't included in the packet, or the length limits for them aren't met. |
+| E:102 \| Datatype | If the provided `val` is not an object, or if the `username` or `pswd` aren't strings. |
+| E:103 \| ID not found | If the given user does not exist. |
+<!-- deno-fmt-ignore-end -->

--- a/docs/api/cloudlink/intro.md
+++ b/docs/api/cloudlink/intro.md
@@ -1,8 +1,3 @@
----
-slug: /cloudlink
-sidebar_label: Intro
----
-
 # Intro
 
 <!--

--- a/docs/api/cloudlink/packets/auth.md
+++ b/docs/api/cloudlink/packets/auth.md
@@ -1,6 +1,6 @@
----
-title: auth packet
----
+-
+
+## title: auth packet
 
 # `auth`
 
@@ -9,12 +9,14 @@ This packet is sent when the user has successfully logged in. It has two keys: a
 
 ## Payload
 
-| Field         | Type                              | Description                                                                                                         |
-| ------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| username      | string                            | The username of the account.                                                                                        |
-| token         | string                            | The token of this connection. A new one will be generated each time, but they don't expire unless manually revoked. |
-| account       | [User](../../objects/user) object | The account information of the logged in account.                                                                   |
-| relationships | array of relationships            | See below for more details.                                                                                         |
+<!-- deno-fmt-ignore-start -->
+| Field | Type | Description |
+| - | - | - |
+| username | string | The username of the account. |
+| token | string | The token of this connection. A new one will be generated each time, but they don't expire unless manually revoked. |
+| account | [User](../../objects/user) object | The account information of the logged in account. |
+| relationships | array of relationships | See below for more details. |
+<!-- deno-fmt-ignore-end -->
 
 ## Relationship
 

--- a/docs/api/cloudlink/packets/auth.md
+++ b/docs/api/cloudlink/packets/auth.md
@@ -1,7 +1,3 @@
--
-
-## title: auth packet
-
 # `auth`
 
 This packet is sent when the user has successfully logged in. It has two keys: a

--- a/docs/api/objects/chat.md
+++ b/docs/api/objects/chat.md
@@ -1,23 +1,27 @@
 # Chat
 
 :::warning
-The chat `livechat` is a special chat. It doesn't require you to be a
-member to access it, posts aren't saved to the database, and the chat nor its
-previous posts can be fetched.
+
+The chat `livechat` is a special chat. It doesn't require you to be a member to
+access it, posts aren't saved to the database, and the chat nor its previous
+posts can be fetched.
+
 :::
 
 ### Structure
 
-| Field       | Type               | Description                                                        | Optional |
-| ----------- | ------------------ | ------------------------------------------------------------------ | -------- |
-| _id         | UUID4              | The chat's UUID4.                                                  |          |
-| type        | integer            | The type of the chat. Will be `0` for group chats and `1` for DMs. |          |
-| nickname*   | string             | The nickname of the chat.                                          | ✓        |
-| owner*      | string             | The username of the user who owns the chat.                        | ✓        |
-| members     | array of usernames | The usernames of the users who are a member of the chat.           |          |
-| created     | integer            | The chat's creation timestamp in Unix seconds.                     |          |
-| last_active | integer            | The timestamp in Unix seconds of the last post in the chat.        |          |
-| deleted     | boolean            | Whether the chat is soft-deleted by a moderator.                   |          |
+<!-- deno-fmt-ignore-start -->
+| Field | Type | Description | Optional |
+| - | - | - | - |
+| _id | UUID4 | The chat's UUID4. | |
+| type | integer | The type of the chat. Will be `0` for group chats and `1` for DMs. | |
+| nickname* | string | The nickname of the chat. | ✓ |
+| owner* | string | The username of the user who owns the chat. | ✓ |
+| members | array of usernames | The usernames of the users who are a member of the chat. | |
+| created | integer | The chat's creation timestamp in Unix seconds. | |
+| last_active | integer | The timestamp in Unix seconds of the last post in the chat. | |
+| deleted | boolean | Whether the chat is soft-deleted by a moderator. | |
+<!-- deno-fmt-ignore-end -->
 
 **\* These fields are only returned when the chat is a group chat.**
 

--- a/docs/api/objects/extended-timestamp.md
+++ b/docs/api/objects/extended-timestamp.md
@@ -1,27 +1,25 @@
 # Extended Timestamp
 
-:::info
-The Extended Timestamp object is only used within the `t` field on
-[Post objects](./post). It should not appear anywhere else.
-:::
+:::info The Extended Timestamp object is only used within the `t` field on
+[Post objects](./post). It should not appear anywhere else. :::
 
-:::warning
-Every field apart from `e` in the extended timestamp object is based
+:::warning Every field apart from `e` in the extended timestamp object is based
 on the server's current timezone. This can cause weird behavior if the server's
-timezone changes (e.g. daylight savings).
-:::
+timezone changes (e.g. daylight savings). :::
 
 ### Structure
 
-| Field | Type    | Description  |
-| ----- | ------- | ------------ |
-| d     | string  | Day          |
-| mo    | string  | Month        |
-| y     | string  | Year         |
-| h     | string  | Hour         |
-| mi    | string  | Minute       |
-| s     | string  | Second       |
-| e     | integer | Unix seconds |
+<!-- deno-fmt-ignore-start -->
+| Field | Type | Description |
+| - | - | - |
+| d | string | Day |
+| mo | string | Month |
+| y | string | Year |
+| h | string | Hour |
+| mi | string | Minute |
+| s | string | Second |
+| e | integer | Unix seconds |
+<!-- deno-fmt-ignore-end -->
 
 ### Example
 

--- a/docs/api/objects/extended-timestamp.md
+++ b/docs/api/objects/extended-timestamp.md
@@ -1,11 +1,19 @@
 # Extended Timestamp
 
-:::info The Extended Timestamp object is only used within the `t` field on
-[Post objects](./post). It should not appear anywhere else. :::
+:::info
 
-:::warning Every field apart from `e` in the extended timestamp object is based
-on the server's current timezone. This can cause weird behavior if the server's
-timezone changes (e.g. daylight savings). :::
+The Extended Timestamp object is only used within the `t` field on
+[Post objects](./post). It should not appear anywhere else.
+
+:::
+
+:::warning
+
+Every field apart from `e` in the extended timestamp object is based on the
+server's current timezone. This can cause weird behavior if the server's
+timezone changes (e.g. daylight savings).
+
+:::
 
 ### Structure
 

--- a/docs/api/objects/post.md
+++ b/docs/api/objects/post.md
@@ -2,20 +2,22 @@
 
 ### Structure
 
-| Field        | Type                                              | Description                                                                              | Optional |
-| ------------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------- |
-| _id          | UUID4                                             | The post's UUID4.                                                                        |          |
-| post_id      | UUID4                                             | The post's UUID4.                                                                        |          |
-| post_origin  | string/UUID4                                      | Where the post was created. Can be `"home"`, `"inbox"`, `"livechat"`, or a chat's UUID4. |          |
-| type         | integer                                           | The post's type.                                                                         |          |
-| t            | [Extended Timestamp](./extended-timestamp) object | The post's creation timestamp.                                                           |          |
-| u            | string                                            | The username of the post author.                                                         |          |
-| p            | string                                            | The content of the post.                                                                 |          |
-| unfiltered_p | string                                            | The non-filtered content of the post.                                                    | ✓        |
-| pinned       | boolean                                           | Whether the post is pinned.                                                              |          |
-| isDeleted    | boolean                                           | Whether the post is deleted.                                                             |          |
-| mod_deleted  | boolean                                           | Whether the post was deleted by a moderator.                                             | ✓        |
-| deleted_at   | integer                                           | The post's deletion timestamp in Unix seconds.                                           | ✓        |
+<!-- deno-fmt-ignore-start -->
+| Field | Type | Description | Optional |
+| - | - | - | - |
+| _id | UUID4 | The post's UUID4. | |
+| post_id | UUID4 | The post's UUID4. | |
+| post_origin | string/UUID4 | Where the post was created. Can be `"home"`, `"inbox"`, `"livechat"`, or a chat's UUID4. | |
+| type | integer | The post's type. | |
+| t | [Extended Timestamp](./extended-timestamp) object | The post's creation timestamp. | |
+| u | string | The username of the post author. | |
+| p | string | The content of the post. | |
+| unfiltered_p | string | The non-filtered content of the post. | ✓ |
+| pinned | boolean | Whether the post is pinned. | |
+| isDeleted | boolean | Whether the post is deleted. | |
+| mod_deleted | boolean | Whether the post was deleted by a moderator. | ✓ |
+| deleted_at | integer | The post's deletion timestamp in Unix seconds. | ✓ |
+<!-- deno-fmt-ignore-end -->
 
 ### Examples
 

--- a/docs/api/objects/user-ban.md
+++ b/docs/api/objects/user-ban.md
@@ -1,7 +1,11 @@
 # User Ban
 
-:::info The User Ban object is only used within the `ban` field on
-[User objects](./user). It should not appear anywhere else. :::
+:::info
+
+The User Ban object is only used within the `ban` field on
+[User objects](./user). It should not appear anywhere else.
+
+:::
 
 ### Structure
 

--- a/docs/api/objects/user-ban.md
+++ b/docs/api/objects/user-ban.md
@@ -1,18 +1,18 @@
 # User Ban
 
-:::info
-The User Ban object is only used within the `ban` field on
-[User objects](./user). It should not appear anywhere else.
-:::
+:::info The User Ban object is only used within the `ban` field on
+[User objects](./user). It should not appear anywhere else. :::
 
 ### Structure
 
-| Field         | Type    | Description                                                                                                               |
-| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
-| state         | string  | The current state of the ban. Can be `"none"`, `"temp_restriction"`, `"perm_restriction"`, `"temp_ban"`, or `"perm_ban"`. |
-| restrictions* | integer |                                                                                                                           |
-| expires**     | integer | The expiration timestamp of the ban in Unix seconds.                                                                      |
-| reason        | string  | The reason for the ban.                                                                                                   |
+<!-- deno-fmt-ignore-start -->
+| Field | Type | Description |
+| - | - | - |
+| state | string | The current state of the ban. Can be `"none"`, `"temp_restriction"`, `"perm_restriction"`, `"temp_ban"`, or `"perm_ban"`. |
+| restrictions* | integer | |
+| expires** | integer | The expiration timestamp of the ban in Unix seconds. |
+| reason | string | The reason for the ban. |
+<!-- deno-fmt-ignore-end -->
 
 **\* These fields are only effective when `state` is set to `"temp_restriction"`
 or `"perm_restriction"`.**

--- a/docs/api/objects/user-settings.md
+++ b/docs/api/objects/user-settings.md
@@ -1,24 +1,24 @@
 # User Settings
 
-:::tip
-These fields will be **appended onto the [User object](/objects/user)**
-when a user is fetching their own user profile.
-:::
+:::tip These fields will be **appended onto the [User object](/objects/user)**
+when a user is fetching their own user profile. :::
 
 ### Structure
 
-| Field              | Type            | Description                                                              |
-| ------------------ | --------------- | ------------------------------------------------------------------------ |
-| unread_inbox       | boolean         | Whether the user has an unread inbox message.                            |
-| theme              | string          | The user's prefered theme (usually "orange", "blue", or a custom theme). |
-| mode               | boolean         | Whether the user prefers light mode.                                     |
-| layout             | string          | The user's preferred layout (usually "new" or "old").                    |
-| sfx                | boolean         | Whether the user prefers sound effects.                                  |
-| bgm                | boolean         | Whether the user prefers background music.                               |
-| bgm_song           | integer         | The user's preferred background music song.                              |
-| hide_blocked_users | boolean         | Whether the user prefers to hide blocked users.                          |
-| active_dms         | array of UUID4s | An array of the last 150 direct message chat UUID4s the user has open.   |
-| favorited_chats    | array of UUID4s | An array of the chat UUID4s the user has favorited.                      |
+<!-- deno-fmt-ignore-start -->
+| Field | Type | Description |
+| - | - | - |
+| unread_inbox | boolean | Whether the user has an unread inbox message. |
+| theme | string | The user's prefered theme (usually "orange", "blue", or a custom theme). |
+| mode | boolean | Whether the user prefers light mode. |
+| layout | string | The user's preferred layout (usually "new" or "old"). |
+| sfx | boolean | Whether the user prefers sound effects. |
+| bgm | boolean | Whether the user prefers background music. |
+| bgm_song | integer | The user's preferred background music song. |
+| hide_blocked_users | boolean | Whether the user prefers to hide blocked users. |
+| active_dms | array of UUID4s | An array of the last 150 direct message chat UUID4s the user has open. |
+| favorited_chats | array of UUID4s | An array of the chat UUID4s the user has favorited. |
+<!-- deno-fmt-ignore-end -->
 
 ### Example
 

--- a/docs/api/objects/user-settings.md
+++ b/docs/api/objects/user-settings.md
@@ -1,7 +1,11 @@
 # User Settings
 
-:::tip These fields will be **appended onto the [User object](/objects/user)**
-when a user is fetching their own user profile. :::
+:::tip
+
+These fields will be **appended onto the [User object](/objects/user)** when a
+user is fetching their own user profile.
+
+:::
 
 ### Structure
 

--- a/docs/api/objects/user.md
+++ b/docs/api/objects/user.md
@@ -2,23 +2,25 @@
 
 ### Structure
 
-| Field          | Type                          | Description                                                                                    | Optional | Deprecated |
-| -------------- | ----------------------------- | ---------------------------------------------------------------------------------------------- | -------- | ---------- |
-| _id            | string                        | The user's username.                                                                           |          |            |
-| lower_username | string                        | The lower-case version of the user's username.                                                 |          |            |
-| uuid           | UUID4 or null                 | The user's UUID4.                                                                              |          |            |
-| created        | integer or null               | The user's creation timestamp in Unix seconds.                                                 |          |            |
-| pfp_data       | integer or null               | The user's selected profile picture.                                                           |          |            |
-| avatar         | string                        | The ID of the avatar the user has. If the user has not set an avatar, this is an empty string. |          |            |
-| avatar_color   | string                        | The border color of the avatar. A six-digit hex color.                                         |          |            |
-| quote          | string or null                | The user's quote.                                                                              |          |            |
-| flags          | integer                       | The user's flags.                                                                              |          |            |
-| permissions    | integer or null               | The user's admin permissions. See below for details.                                           |          |            |
-| lvl            | integer                       | The user's admin level.                                                                        |          | ✓          |
-| ban*           | [User Ban object](./user-ban) | Ban status associated with the user.                                                           | ✓        |            |
-| banned         | boolean                       | Whether the user is currently banned.                                                          |          |            |
-| last_seen      | integer or null               | The timestamp in Unix seconds of when the user was last online.                                |          |            |
-| delete_after*  | integer or null               | The timestamp in Unix seconds of when the user is scheduled to be deleted.                     | ✓        |            |
+<!-- deno-fmt-ignore-start -->
+| Field | Type | Description | Optional | Deprecated |
+| - | - | - | - | - |
+| _id | string | The user's username. | | |
+| lower_username | string | The lower-case version of the user's username. | | |
+| uuid | UUID4 or null | The user's UUID4. | | |
+| created | integer or null | The user's creation timestamp in Unix seconds. | | |
+| pfp_data | integer or null | The user's selected profile picture. | | |
+| avatar | string | The ID of the avatar the user has. If the user has not set an avatar, this is an empty string. | | |
+| avatar_color | string | The border color of the avatar. A six-digit hex color. | | |
+| quote | string or null | The user's quote. | | |
+| flags | integer | The user's flags. | | |
+| permissions | integer or null | The user's admin permissions. See below for details. | | |
+| lvl | integer | The user's admin level. | | ✓ |
+| ban* | [User Ban object](./user-ban) | Ban status associated with the user. | ✓ | |
+| banned | boolean | Whether the user is currently banned. | | |
+| last_seen | integer or null | The timestamp in Unix seconds of when the user was last online. | | |
+| delete_after* | integer or null | The timestamp in Unix seconds of when the user is scheduled to be deleted. | ✓ | |
+<!-- deno-fmt-ignore-end -->
 
 **\* These fields are only returned when a user is fetching their own user
 profile.**
@@ -30,28 +32,30 @@ numbers, that should then be converted to binary. The indices where there is a
 binary `1` show that the permission at that index is given. In many languages,
 this can be consisely written as `(permissions & (1 << permission)) != 0`.
 
-| Index | Number | Permission                                                 |
-| ----- | ------ | ---------------------------------------------------------- |
-| 0     | 1      | Sysadmin; can do anything                                  |
-| 1     | 2      | Can view reports                                           |
-| 2     | 4      | Can handle reports                                         |
-| 3     | 8      | Can view notes on posts and users                          |
-| 4     | 16     | Can edit notes on posts or users                           |
-| 5     | 32     | Can view posts in any chat                                 |
-| 6     | 64     | Can delete posts in any chat                               |
-| 7     | 128    | Can view which alts a user has                             |
-| 8     | 256    | Can send alerts                                            |
-| 9     | 512    | Can kick users                                             |
-| 10    | 1024   | Can clear a user's profile details                         |
-| 11    | 2048   | Can view ban states                                        |
-| 12    | 4096   | Can ban or unban users                                     |
-| 13    | 8192   | Can delete users                                           |
-| 14    | 16384  | Can view the IP adress of users                            |
-| 15    | 32768  | Can block certain IP adresses                              |
-| 16    | 65536  | Can view chat information                                  |
-| 17    | 131072 | Can edit chat information                                  |
-| 18    | 262144 | Can send announcements                                     |
-| 19    | 524288 | Can change which words are blocked by the profanity filter |
+<!-- deno-fmt-ignore-start -->
+| Index | Number | Permission |
+| - | - | - |
+| 0 | 1 | Sysadmin; can do anything |
+| 1 | 2 | Can view reports |
+| 2 | 4 | Can handle reports |
+| 3 | 8 | Can view notes on posts and users |
+| 4 | 16 | Can edit notes on posts or users |
+| 5 | 32 | Can view posts in any chat |
+| 6 | 64 | Can delete posts in any chat |
+| 7 | 128 | Can view which alts a user has |
+| 8 | 256 | Can send alerts |
+| 9 | 512 | Can kick users |
+| 10 | 1024 | Can clear a user's profile details |
+| 11 | 2048 | Can view ban states |
+| 12 | 4096 | Can ban or unban users |
+| 13 | 8192 | Can delete users |
+| 14 | 16384 | Can view the IP adress of users |
+| 15 | 32768 | Can block certain IP adresses |
+| 16 | 65536 | Can view chat information |
+| 17 | 131072 | Can edit chat information |
+| 18 | 262144 | Can send announcements |
+| 19 | 524288 | Can change which words are blocked by the profanity filter |
+<!-- deno-fmt-ignore-end -->
 
 ### Examples
 

--- a/docs/api/rest-api/endpoints/post_home.md
+++ b/docs/api/rest-api/endpoints/post_home.md
@@ -4,17 +4,21 @@ This endpoint is used to post to add a post to home. It requires authorization.
 
 ## Body
 
-| Key         | Description                                                                                                                      | Required |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| content     | The post content. From 0 to 4,000 characters. If left at zero characters or left out, at least one attachment has to be present. | No       |
-| attachments | A list of attachment IDs uploaded via uploads.meower.org. At most 10.                                                            | No       |
-| reply_to    | A list of post IDs to reply to.                                                                                                  | No       |
+<!-- deno-fmt-ignore-start -->
+| Key | Description | Required |
+| - | - | - |
+| content | The post content. From 0 to 4,000 characters. If left at zero characters or left out, at least one attachment has to be present. | No |
+| attachments | A list of attachment IDs uploaded via uploads.meower.org. At most 10. | No |
+| reply_to | A list of post IDs to reply to. | No |
+<!-- deno-fmt-ignore-end -->
 
 ## Response
 
-| Status | Body                                                   | Description                                                                                                                               |
-| ------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| 200    | [Post](../../objects/post)                             | The resulting post. This may be returned later than broadcasted by Cloudlink.                                                             |
-| 400    | `{ "error": true, "type": "tooManyAttachments" }`      | If there are more than 10 attachments.                                                                                                    |
-| 403    | `{ "error": true, "type": "accountBanned" }`           | If the account is banned.                                                                                                                 |
-| 500    | `{ "error": true, "type": "unableToClaimAttachment" }` | If one of the attachments could not be claimed. This can happen when it has already expired or the ID is incorrect, or be a server issue. |
+<!-- deno-fmt-ignore-start -->
+| Status | Body | Description |
+| - | - | - |
+| 200 | [Post](../../objects/post) | The resulting post. This may be returned later than broadcasted by Cloudlink. |
+| 400 | `{ "error": true, "type": "tooManyAttachments" }` | If there are more than 10 attachments. |
+| 403 | `{ "error": true, "type": "accountBanned" }` | If the account is banned. |
+| 500 | `{ "error": true, "type": "unableToClaimAttachment" }` | If one of the attachments could not be claimed. This can happen when it has already expired or the ID is incorrect, or be a server issue. |
+<!-- deno-fmt-ignore-end -->

--- a/docs/api/rest-api/endpoints/post_posts_chat_id.md
+++ b/docs/api/rest-api/endpoints/post_posts_chat_id.md
@@ -5,19 +5,23 @@ authorization.
 
 ## Body
 
-| Key         | Description                                                                                                                      | Required |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| content     | The post content. From 0 to 4,000 characters. If left at zero characters or left out, at least one attachment has to be present. | No       |
-| attachments | A list of attachment IDs uploaded via uploads.meower.org. At most 10.                                                            | No       |
-| reply_to    | A list of post IDs to reply to.                                                                                                  | No       |
+<!-- deno-fmt-ignore-start -->
+| Key | Description | Required |
+| - | - | - |
+| content | The post content. From 0 to 4,000 characters. If left at zero characters or left out, at least one attachment has to be present. | No |
+| attachments | A list of attachment IDs uploaded via uploads.meower.org. At most 10. | No |
+| reply_to | A list of post IDs to reply to. | No |
+<!-- deno-fmt-ignore-end -->
 
 ## Response
 
-| Status | Body                                                   | Description                                                                                                                               |
-| ------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| 200    | [Post](../../objects/post)                             | The resulting post. This may be returned later than broadcasted by Cloudlink.                                                             |
-| 400    | `{ "error": true, "type": "tooManyAttachments" }`      | If there are more than 10 attachments.                                                                                                    |
-| 403    |                                                        | If the account is attempting to message a user that is blocked or that has the account blocked.                                           |
-| 403    | `{ "error": true, "type": "accountBanned" }`           | If the account is banned.                                                                                                                 |
-| 404    |                                                        | If the chat can't be found, or the account is not in the chat.                                                                            |
-| 500    | `{ "error": true, "type": "unableToClaimAttachment" }` | If one of the attachments could not be claimed. This can happen when it has already expired or the ID is incorrect, or be a server issue. |
+<!-- deno-fmt-ignore-start -->
+| Status | Body | Description |
+| - | - | - |
+| 200 | [Post](../../objects/post) | The resulting post. This may be returned later than broadcasted by Cloudlink. |
+| 400 | `{ "error": true, "type": "tooManyAttachments" }` | If there are more than 10 attachments. |
+| 403 | | If the account is attempting to message a user that is blocked or that has the account blocked. |
+| 403 | `{ "error": true, "type": "accountBanned" }` | If the account is banned. |
+| 404 | | If the chat can't be found, or the account is not in the chat. |
+| 500 | `{ "error": true, "type": "unableToClaimAttachment" }` | If one of the attachments could not be claimed. This can happen when it has already expired or the ID is incorrect, or be a server issue. |
+<!-- deno-fmt-ignore-end -->

--- a/docs/api/rest-api/rest-api.md
+++ b/docs/api/rest-api/rest-api.md
@@ -24,13 +24,15 @@ response. For other status codes, this key is set to `true`, and another key,
 `type`, is added. Many status codes have predefined messages, listed below.
 Different ones may be used for certain errors by some endpoints.
 
-| Status code | Error type           | Notes                                                                                                                                        |
-| ----------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| 400         | `badRequest`         | This is sent when the body is not JSON or follows the schema required by the endpoint, or when the `Content-Type` header is set incorrectly. |
-| 401         | `Unauthorized`       | This is sent by endpoints that require authorization if no token is passed.                                                                  |
-| 403         | `missingPermissions` |                                                                                                                                              |
-| 404         | `notFound`           | This is sent when an endpoint is not found, but also when specific data of an endpoint is not found.                                         |
-| 405         | `methodNotAllowed`   |                                                                                                                                              |
-| 429         | `tooManyRequests`    | This can be sent by any endpoint.                                                                                                            |
-| 500         | `Internal`           | This can be sent by any endpoint.                                                                                                            |
-| 501         | `notImplemented`     |                                                                                                                                              |
+<!-- deno-fmt-ignore-start -->
+| Status code | Error type | Notes |
+| - | - | - |
+| 400 | `badRequest` | This is sent when the body is not JSON or follows the schema required by the endpoint, or when the `Content-Type` header is set incorrectly. |
+| 401 | `Unauthorized` | This is sent by endpoints that require authorization if no token is passed. |
+| 403 | `missingPermissions` | |
+| 404 | `notFound` | This is sent when an endpoint is not found, but also when specific data of an endpoint is not found. |
+| 405 | `methodNotAllowed` | |
+| 429 | `tooManyRequests` | This can be sent by any endpoint. |
+| 500 | `Internal` | This can be sent by any endpoint. |
+| 501 | `notImplemented` | |
+<!-- deno-fmt-ignore-end -->


### PR DESCRIPTION
- Set VSCode to format everything with `deno fmt`
- Format all Markdown files with `deno fmt`
  - These blank lines are necessary because `deno fmt` was annoying and would break it otherwise - Prettier would be better about this but this uses `deno fmt` already
    ```md
    :::warning


    The chat `livechat` is a special chat. It doesn't require you to be a member to
    access it, posts aren't saved to the database, and the chat nor its previous
    posts can be fetched.


    :::
    ```
- Add `deno-fmt-ignore` sections around tables
